### PR TITLE
Adjust Scheduled Talk Display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,7 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  # Factory Girl Gem setting up sample data for tests
+  gem 'factory_girl_rails', '~> 4.0'
+
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,11 @@ GEM
       warden (~> 1.2.3)
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -165,6 +170,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   devise
+  factory_girl_rails (~> 4.0)
   jbuilder (~> 2.0)
   jquery-rails
   pg

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,2 +1,11 @@
 module TalksHelper
+
+  def previous_talk
+    @talks.where("DATE(speak_date) < ?", Date.today).count
+  end
+
+  def upcoming_talk
+    @talks.where("DATE(speak_date) >= ?", Date.today).count
+  end
+
 end

--- a/app/views/partials/_previousTalks.html.erb
+++ b/app/views/partials/_previousTalks.html.erb
@@ -1,0 +1,31 @@
+<div class="col-xs-10 col-xs-offset-1">
+  <h1 class="col-xs-10 col-xs-offset-1 text-center">
+    Previous Talks
+  </h1>
+  <% @talks.order(:topic).each do |talk| %>
+    <% if talk.speak_date != nil && talk.speak_date < Date.today %>
+      <div class="ice col-xs-12 col-md-4">
+        <h2><%= link_to talk.topic, talk_path(talk) %></h2>
+        <h4><%= truncate talk.description, length: 80 %></h4>
+        <% if talk.description.length > 80 %>
+          <p><%= link_to "Read More...", talk_path(talk) %></p>
+        <% end %>
+        <% if talk.is_assigned == true %>
+          <p>
+            <%= link_to "Assigned", assigned_talk_path(talk), method: :patch %>
+            <i class="glyphicon glyphicon-star"></i>
+          </p>
+          <p>Talk is assigned to: <%= talk.assigned_to %></p>
+        <% else %>
+          <p>
+            <%= link_to "Unassigned", assigned_talk_path(talk), method: :patch %>
+            <i class="glyphicon glyphicon-star-empty"></i>
+          </p><br />
+        <% end %>
+        <br />
+        <h4 class="pull-left"><%= pluralize(talk.votes.count, "vote") %>&nbsp</h4>
+        <p class="pull-right"><%= button_to '+1', upvote_talk_path(talk), class: "btn btn-sm btn-info", method: :post %></p>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/partials/_scheduledTalks.html.erb
+++ b/app/views/partials/_scheduledTalks.html.erb
@@ -1,0 +1,31 @@
+<div class="col-xs-10 col-xs-offset-1">
+  <h1 class="col-xs-10 col-xs-offset-1 text-center">
+    Upcoming scheduled talks!
+  </h1>
+  <% @talks.order(:topic).each do |talk| %>
+    <% if talk.is_assigned == true && talk.speak_date != nil && talk.speak_date >= Date.today %>
+      <div class="ice col-xs-12 col-md-4">
+        <h2><%= link_to talk.topic, talk_path(talk) %></h2>
+        <h4><%= truncate talk.description, length: 80 %></h4>
+        <% if talk.description.length > 80 %>
+          <p><%= link_to "Read More...", talk_path(talk) %></p>
+        <% end %>
+        <% if talk.is_assigned == true %>
+          <p>
+            <%= link_to "Assigned", assigned_talk_path(talk), method: :patch %>
+            <i class="glyphicon glyphicon-star"></i>
+          </p>
+          <p>Talk is assigned to: <%= talk.assigned_to %></p>
+        <% else %>
+          <p>
+            <%= link_to "Unassigned", assigned_talk_path(talk), method: :patch %>
+            <i class="glyphicon glyphicon-star-empty"></i>
+          </p><br />
+        <% end %>
+        <br />
+        <h4 class="pull-left"><%= pluralize(talk.votes.count, "vote") %>&nbsp</h4>
+        <p class="pull-right"><%= button_to '+1', upvote_talk_path(talk), class: "btn btn-sm btn-info", method: :post %></p>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/partials/_unscheduledTalks.html.erb
+++ b/app/views/partials/_unscheduledTalks.html.erb
@@ -1,0 +1,27 @@
+<h1 class="col-xs-10 col-xs-offset-1 text-center">Suggested and Unscheduled Talks</h1>
+<div class="col-xs-10 col-xs-offset-1">
+  <% @talks.order(:topic).each do |talk| %>
+    <div class="ice col-xs-12 col-md-4">
+      <h2><%= link_to talk.topic, talk_path(talk) %></h2>
+      <h4><%= truncate talk.description, length: 80 %></h4>
+      <% if talk.description.length > 80 %>
+        <p><%= link_to "Read More...", talk_path(talk) %></p>
+      <% end %>
+      <% if talk.is_assigned == true %>
+        <p>
+          <%= link_to "Assigned", assigned_talk_path(talk), method: :patch %>
+          <i class="glyphicon glyphicon-star"></i>
+        </p>
+        <p>Talk is assigned to: <%= talk.assigned_to %></p>
+      <% else %>
+        <p>
+          <%= link_to "Unassigned", assigned_talk_path(talk), method: :patch %>
+          <i class="glyphicon glyphicon-star-empty"></i>
+        </p><br />
+      <% end %>
+      <br />
+      <h4 class="pull-left"><%= pluralize(talk.votes.count, "vote") %>&nbsp</h4>
+      <p class="pull-right"><%= button_to '+1', upvote_talk_path(talk), class: "btn btn-sm btn-info", method: :post %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -1,7 +1,9 @@
 <br />
 <br />
 <!-- Start Scheduled Talk Section -->
-<%= render "partials/scheduledTalks" %>
+<% if upcoming_talk >= 1 %>
+  <%= render "partials/scheduledTalks" %>
+<% end %>
 <!-- End of Scheduled Talk Section -->
 <br class="clear" />
 <br />
@@ -11,7 +13,9 @@
 <br class="clear" />
 <br />
 <!-- Begin Previously Given Talks -->
-<%= render "partials/previousTalks" %>
+<% if previous_talk >= 1 %>
+  <%= render "partials/previousTalks" %>
+<% end %>
 <!-- End Previously Given Talks -->
 <br />
 <br />

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -1,68 +1,17 @@
 <br />
 <br />
 <!-- Start Scheduled Talk Section -->
-<div class="col-xs-10 col-xs-offset-1">
-  <h1 class="col-xs-10 col-xs-offset-1 text-center">
-    Upcoming scheduled talks!
-  </h1>
-  <% @talks.order(:topic).each do |talk| %>
-    <% if talk.is_assigned == true && talk.speak_date != nil %>
-      <div class="ice col-xs-12 col-md-4">
-        <h2><%= link_to talk.topic, talk_path(talk) %></h2>
-        <h4><%= truncate talk.description, length: 80 %></h4>
-        <% if talk.description.length > 80 %>
-          <p><%= link_to "Read More...", talk_path(talk) %></p>
-        <% end %>
-        <% if talk.is_assigned == true %>
-          <p>
-            <%= link_to "Assigned", assigned_talk_path(talk), method: :patch %>
-            <i class="glyphicon glyphicon-star"></i>
-          </p>
-          <p>Talk is assigned to: <%= talk.assigned_to %></p>
-        <% else %>
-          <p>
-            <%= link_to "Unassigned", assigned_talk_path(talk), method: :patch %>
-            <i class="glyphicon glyphicon-star-empty"></i>
-          </p><br />
-        <% end %>
-        <br />
-        <h4 class="pull-left"><%= pluralize(talk.votes.count, "vote") %>&nbsp</h4>
-        <p class="pull-right"><%= button_to '+1', upvote_talk_path(talk), class: "btn btn-sm btn-info", method: :post %></p>
-      </div>
-    <% end %>
-  <% end %>
-</div>
+<%= render "partials/scheduledTalks" %>
 <!-- End of Scheduled Talk Section -->
 <br class="clear" />
 <br />
 <!-- Start of Uncheduled Talk Section -->
-<h1 class="col-xs-10 col-xs-offset-1 text-center">Suggested and Unscheduled Talks</h1>
-<div class="col-xs-10 col-xs-offset-1">
-  <% @talks.order(:topic).each do |talk| %>
-    <div class="ice col-xs-12 col-md-4">
-      <h2><%= link_to talk.topic, talk_path(talk) %></h2>
-      <h4><%= truncate talk.description, length: 80 %></h4>
-      <% if talk.description.length > 80 %>
-        <p><%= link_to "Read More...", talk_path(talk) %></p>
-      <% end %>
-      <% if talk.is_assigned == true %>
-        <p>
-          <%= link_to "Assigned", assigned_talk_path(talk), method: :patch %>
-          <i class="glyphicon glyphicon-star"></i>
-        </p>
-        <p>Talk is assigned to: <%= talk.assigned_to %></p>
-      <% else %>
-        <p>
-          <%= link_to "Unassigned", assigned_talk_path(talk), method: :patch %>
-          <i class="glyphicon glyphicon-star-empty"></i>
-        </p><br />
-      <% end %>
-      <br />
-      <h4 class="pull-left"><%= pluralize(talk.votes.count, "vote") %>&nbsp</h4>
-      <p class="pull-right"><%= button_to '+1', upvote_talk_path(talk), class: "btn btn-sm btn-info", method: :post %></p>
-    </div>
-  <% end %>
-</div>
+<%= render "partials/unscheduledTalks" %>
 <!-- End of Uncheduled Talk Section -->
+<br class="clear" />
+<br />
+<!-- Begin Previously Given Talks -->
+<%= render "partials/previousTalks" %>
+<!-- End Previously Given Talks -->
 <br />
 <br />

--- a/test/factories/talks.rb
+++ b/test/factories/talks.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :topic, class: Talk do
+    topic "TDD"
+    description "Test Driven Development"
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  # Admin User
+  factory :admin, class: User do
+    first_name "Tyler"
+    last_name "Durden"
+    email "tyler@example.com"
+    password "password"
+    password_confirmation { |u| u.password }
+    admin true
+  end
+  # Standard User
+  factory :user do
+    first_name "Butch"
+    last_name "Cassidy"
+    email "butch@example.com"
+    password "password"
+    password_confirmation { |u| u.password }
+    admin false
+  end
+end

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -1,7 +1,15 @@
 require 'test_helper'
 
 class TalkTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "create a topic" do
+    talk = FactoryGirl.create(:topic)
+    assert_equal "TDD", talk.topic
+  end
+
+  test "assign a topic to a person" do
+    talk = FactoryGirl.create(:topic)
+    talk.update_attributes(is_assigned: true, assigned_to: "Tyler" )
+    assert_equal true, talk.is_assigned
+    assert_equal "Tyler", talk.assigned_to
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,14 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "standard user creation" do
+    user = FactoryGirl.create(:user)
+    assert_equal "Butch", user.first_name
+  end
+
+  test "admin user creation" do
+    admin = FactoryGirl.create(:admin)
+    assert_equal "Tyler", admin.first_name
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,16 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'factory_girl'
+
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+  # fixtures :all
 
   # Add more helper methods to be used by all tests here...
+end
+
+class ActionController::TestCase
+  include Devise::TestHelpers
 end


### PR DESCRIPTION
Created 3 sections for displaying content:
- Assigned and Scheduled
- Unassigned/Assigned and Unscheduled
- Previously Scheduled Talks (talks already given)

I put all three of these sections in partials to segment and make it more easy to refactor later. Each section is rendered on the index page. Additionally created helper methods to display the upcoming scheduled and previously scheduled content sections if there is content to be displayed. 
