### PR TITLE
Only one vote per user

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,5 +1,5 @@
 class TalksController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :assigned]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :assigned, :upvote]
 
   def index
     @unscheduled_talks = Talk.unscheduled
@@ -41,8 +41,8 @@ class TalksController < ApplicationController
   end
 
   def upvote
-    @talk = Talk.find(params[:id])
-    @talk.votes.create
+    talk = Talk.find(params[:id])
+    current_user.upvote(talk)
     redirect_to(talks_path)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,13 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :talks, dependent: :destroy
+  has_many :votes
+
+  def upvote(talk)
+    votes.create(talk: talk) unless voted?(talk)
+  end
+
+  def voted?(talk)
+    votes.where(talk: talk).any?
+  end
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,3 +1,4 @@
 class Vote < ActiveRecord::Base
   belongs_to :talk
+  belongs_to :user
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class TalksControllerTest < ActionController::TestCase
-
   test "do not add blank topics" do
     user = FactoryGirl.create(:user)
     sign_in user
@@ -12,6 +11,41 @@ class TalksControllerTest < ActionController::TestCase
         description: nil
       }
     end
+  end
 
+  test "no user upvote test" do
+    # create talk to collect votes
+    talk = FactoryGirl.create(:topic)
+
+    # ensure no votes pass into talk when no user is signed in
+    assert_no_difference "Talk.find(talk.id).votes.count" do
+      post :upvote, id: talk.id
+    end
+
+    # redirect to sign in page
+    assert_redirected_to new_user_session_path
+  end
+
+  test "user has already upvoted" do
+    # create talk to collect votes
+    talk = FactoryGirl.create(:topic)
+
+    # create user and sign in
+    user = FactoryGirl.create(:user)
+    sign_in user
+
+    # first vote should go through and redirect to home page
+    assert_difference "Talk.find(talk.id).votes.count" do
+      post :upvote, id: talk.id
+    end
+
+    assert_redirected_to talks_path
+
+    # second vote should not go through and should still redirect to home page
+    assert_no_difference "Talk.find(talk.id).votes.count" do
+      post :upvote, id: talk.id
+    end
+
+    assert_redirected_to talks_path
   end
 end


### PR DESCRIPTION
Require user to be signed in and submit no more than one vote per talk.
Fixes #6 and #7
