### PR TITLE
Use association for assigning and unassigning talks.

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,5 +1,7 @@
 class TalksController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :assigned, :upvote]
+  before_action :authenticate_user!, only: [
+    :new, :create, :edit, :assign, :unassign, :upvote
+  ]
 
   def index
     @unscheduled_talks = Talk.unscheduled
@@ -46,15 +48,16 @@ class TalksController < ApplicationController
     redirect_to(talks_path)
   end
 
-  def assigned
-    @talk = Talk.find(params[:id])
+  def assign
+    talk = Talk.find(params[:id])
     user = "#{current_user.first_name} #{current_user.last_name.first}"
-    if @talk.is_assigned == false
-      @talk.update_attributes(is_assigned: true, assigned_to: user)
-    else
-      @talk.update_attributes(is_assigned: false, assigned_to: nil)
-    end
+    talk.update_attributes(is_assigned: true, assigned_to: user)
     redirect_to(talks_path)
+  end
+
+  def unassign
+    talk = Talk.find(params[:id])
+    talk.update_attributes(is_assigned: false, assigned_to: nil)
   end
 
   private
@@ -62,5 +65,4 @@ class TalksController < ApplicationController
   def talk_params
     params.require(:talk).permit(:topic, :description, :speak_date)
   end
-
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -50,14 +50,14 @@ class TalksController < ApplicationController
 
   def assign
     talk = Talk.find(params[:id])
-    user = "#{current_user.first_name} #{current_user.last_name.first}"
-    talk.update_attributes(is_assigned: true, assigned_to: user)
+    current_user.assign(talk)
     redirect_to(talks_path)
   end
 
   def unassign
     talk = Talk.find(params[:id])
-    talk.update_attributes(is_assigned: false, assigned_to: nil)
+    current_user.unassign(talk)
+    redirect_to(talks_path)
   end
 
   private

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,6 +1,7 @@
 class Talk < ActiveRecord::Base
   has_many :votes, dependent: :destroy
   belongs_to :user
+  belongs_to :assignee, class_name: 'User'
 
   scope :unscheduled, -> { where(speak_date: nil).order(:topic) }
   scope :scheduled, -> { where('speak_date >= ?', Date.today).order(:speak_date).order(:topic) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ActiveRecord::Base
 
   has_many :talks, dependent: :destroy
   has_many :votes
+  has_many :assigned_talks, class_name: 'Talk', foreign_key: 'assignee_id'
 
   def upvote(talk)
     votes.create(talk: talk) unless voted?(talk)
@@ -13,5 +14,13 @@ class User < ActiveRecord::Base
 
   def voted?(talk)
     votes.where(talk: talk).any?
+  end
+
+  def assign(talk)
+    talk.update(assignee: self)
+  end
+
+  def unassign(talk)
+    talk.update(assignee: nil) if talk.assignee == self
   end
 end

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -4,12 +4,12 @@
   <% if talk.description.length > 80 %>
     <p><%= link_to "Read More...", talk_path(talk) %></p>
   <% end %>
-  <% if talk.is_assigned == true %>
+  <% if talk.assignee %>
     <p>
       <%= link_to "Assigned", unassign_talk_path(talk), method: :put %>
       <i class="glyphicon glyphicon-star"></i>
     </p>
-    <p>Talk is assigned to: <%= talk.assigned_to %></p>
+    <p>Talk is assigned to: <%= talk.assignee.first_name %></p>
   <% else %>
     <p>
       <%= link_to "Unassigned", assign_talk_path(talk), method: :put %>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -9,7 +9,7 @@
       <%= link_to "Assigned", unassign_talk_path(talk), method: :put %>
       <i class="glyphicon glyphicon-star"></i>
     </p>
-    <p>Talk is assigned to: <%= talk.assignee.first_name %></p>
+    <p>Talk is assigned to: <%= talk.assignee.first_name %> <%= talk.assignee.last_name.first %></p>
   <% else %>
     <p>
       <%= link_to "Unassigned", assign_talk_path(talk), method: :put %>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -6,13 +6,13 @@
   <% end %>
   <% if talk.is_assigned == true %>
     <p>
-      <%= link_to "Assigned", assigned_talk_path(talk), method: :patch %>
+      <%= link_to "Assigned", unassign_talk_path(talk), method: :put %>
       <i class="glyphicon glyphicon-star"></i>
     </p>
     <p>Talk is assigned to: <%= talk.assigned_to %></p>
   <% else %>
     <p>
-      <%= link_to "Unassigned", assigned_talk_path(talk), method: :patch %>
+      <%= link_to "Unassigned", assign_talk_path(talk), method: :put %>
       <i class="glyphicon glyphicon-star-empty"></i>
     </p><br />
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
   resources :talks do
     member do
       post 'upvote'
-      patch 'assigned'
+      put 'assign'
+      put 'unassign'
     end
   end
-
 end

--- a/db/migrate/20150922205344_add_assignee_to_talks.rb
+++ b/db/migrate/20150922205344_add_assignee_to_talks.rb
@@ -1,0 +1,6 @@
+class AddAssigneeToTalks < ActiveRecord::Migration
+  def change
+    add_reference :talks, :assignee, index: true
+    update "UPDATE talks SET assignee_id=(SELECT id FROM users WHERE first_name = split_part(assigned_to, ' ', 1) AND last_name LIKE split_part(assigned_to, ' ', 2) || '%' LIMIT 1)"
+  end
+end

--- a/db/migrate/20150922215620_remove_unused_columns_from_talks.rb
+++ b/db/migrate/20150922215620_remove_unused_columns_from_talks.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedColumnsFromTalks < ActiveRecord::Migration
+  def change
+    remove_column :talks, :is_assigned, :string
+    remove_column :talks, :assigned_to, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150912175720) do
+ActiveRecord::Schema.define(version: 20150922205344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,8 +25,10 @@ ActiveRecord::Schema.define(version: 20150912175720) do
     t.integer  "user_id"
     t.string   "assigned_to"
     t.date     "speak_date"
+    t.integer  "assignee_id"
   end
 
+  add_index "talks", ["assignee_id"], name: "index_talks_on_assignee_id", using: :btree
   add_index "talks", ["user_id"], name: "index_talks_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922205344) do
+ActiveRecord::Schema.define(version: 20150922215620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,11 +19,9 @@ ActiveRecord::Schema.define(version: 20150922205344) do
   create_table "talks", force: :cascade do |t|
     t.string   "topic"
     t.text     "description"
-    t.boolean  "is_assigned", default: false, null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.integer  "user_id"
-    t.string   "assigned_to"
     t.date     "speak_date"
     t.integer  "assignee_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,18 +18,18 @@ User.create([
   ])
 
 # Create Talks
-# Example: Talk.create([{topic: "", description: "", is_assigned: [true/false(false by default)], user_id: integer, assigned_to: ""(nil by default), speak_date: date (nil by default) }])
+# Example: Talk.create([{topic: "", description: "", user_id: integer, assignee_id: integer, speak_date: date (nil by default) }])
 Talk.create([
-  {topic: "Continuous Integration", description: "What is Continuous Integration? How does it work? Travis CI, CodeShip, etc?", is_assigned: false, user_id: 1, assigned_to: nil, speak_date: nil },
-  {topic: "Illustrator for Developers", description: "How to quickly get started with Illustrator and apply it to your workflow.", is_assigned: false, user_id: 1, assigned_to: nil, speak_date: nil },
-  {topic: "Vim: It's Good", description: "Vim, a command line editor. Why you should use it? How you should use it? Advantages/Disadvantages?", is_assigned: false, user_id: 1, assigned_to: nil, speak_date: nil },
-  {topic: "Building a Commenting System in Jekyll", description: "Want readers input on your Jekyll blog? Implement a comments section.", is_assigned: false, user_id: 1, assigned_to: nil, speak_date: nil },
-  {topic: "Debugging Heroku", description: "Cover the common errors, gotchas and methodologies to solve the problem.", is_assigned: false, user_id: 2, assigned_to: nil, speak_date: nil },
-  {topic: "Getting Started With Elasticsearch", description: "Real-time search and data analytics.", is_assigned: false, user_id: 2, assigned_to: nil, speak_date: nil },
-  {topic: "Real-time search and data analytics.", description: "Supercharge your TDD with RSpec.", is_assigned: false, user_id: 2, assigned_to: nil, speak_date: nil },
-  {topic: "HTTParty", description: "Making HTTP fun again. Consume restful web services with ease.", is_assigned: false, user_id: 3, assigned_to: nil, speak_date: nil },
-  {topic: "Redis Getting Started", description: "Exploring data structure servers and how to apply them to our applications.", is_assigned: false, user_id: 3, assigned_to: nil, speak_date: nil },
-  {topic: "Stripe Integration", description: "Integrate simple payment processing into your application.", is_assigned: false, user_id: 3, assigned_to: nil, speak_date: nil },
-  {topic: "Getting Started with Vagrant", description: "Learn the ins and outs of utilizing your Vagrant environment to the fullest.", is_assigned: false, user_id: 4, assigned_to: nil, speak_date: nil },
-  {topic: "Sidekiq", description: "Simple, efficient background processing for Ruby.", is_assigned: false, user_id: 4, assigned_to: nil, speak_date: nil }
+  {topic: "Continuous Integration", description: "What is Continuous Integration? How does it work? Travis CI, CodeShip, etc?", user_id: 1, speak_date: nil },
+  {topic: "Illustrator for Developers", description: "How to quickly get started with Illustrator and apply it to your workflow.", user_id: 1, speak_date: nil },
+  {topic: "Vim: It's Good", description: "Vim, a command line editor. Why you should use it? How you should use it? Advantages/Disadvantages?", user_id: 1, speak_date: nil },
+  {topic: "Building a Commenting System in Jekyll", description: "Want readers input on your Jekyll blog? Implement a comments section.", user_id: 1, speak_date: nil },
+  {topic: "Debugging Heroku", description: "Cover the common errors, gotchas and methodologies to solve the problem.", user_id: 2, speak_date: nil },
+  {topic: "Getting Started With Elasticsearch", description: "Real-time search and data analytics.", user_id: 2, speak_date: nil },
+  {topic: "Real-time search and data analytics.", description: "Supercharge your TDD with RSpec.", user_id: 2, speak_date: nil },
+  {topic: "HTTParty", description: "Making HTTP fun again. Consume restful web services with ease.", user_id: 3, speak_date: nil },
+  {topic: "Redis Getting Started", description: "Exploring data structure servers and how to apply them to our applications.", user_id: 3, speak_date: nil },
+  {topic: "Stripe Integration", description: "Integrate simple payment processing into your application.", user_id: 3, speak_date: nil },
+  {topic: "Getting Started with Vagrant", description: "Learn the ins and outs of utilizing your Vagrant environment to the fullest.", user_id: 4, speak_date: nil },
+  {topic: "Sidekiq", description: "Simple, efficient background processing for Ruby.", user_id: 4, speak_date: nil }
   ])

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -48,4 +48,31 @@ class TalksControllerTest < ActionController::TestCase
 
     assert_redirected_to talks_path
   end
+
+  test "must be signed in to assign talk" do
+    talk = FactoryGirl.create(:topic)
+    put :assign, id: talk.id
+    assert_redirected_to new_user_session_path
+    assert talk.assignee.nil?
+  end
+
+  test "must be correct user to unassign talk" do
+    talk = FactoryGirl.create(:topic)
+    user = FactoryGirl.create(:user)
+    user.assign(talk)
+    other_user = FactoryGirl.create(:user, email: 'other_user@example.com')
+    sign_in other_user
+    put :unassign, id: talk.id
+    talk.reload
+    assert_equal user, talk.assignee
+  end
+
+  test "can assign talk to self" do
+    talk = FactoryGirl.create(:topic)
+    user = FactoryGirl.create(:user)
+    sign_in user
+    put :assign, id: talk.id
+    talk.reload
+    assert_equal user, talk.assignee
+  end
 end

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -8,9 +8,9 @@ class TalkTest < ActiveSupport::TestCase
 
   test "assign a topic to a person" do
     talk = FactoryGirl.create(:topic)
-    talk.update_attributes(is_assigned: true, assigned_to: "Tyler" )
-    assert_equal true, talk.is_assigned
-    assert_equal "Tyler", talk.assigned_to
+    user = FactoryGirl.create(:user)
+    user.assign(talk)
+    assert_equal user, talk.assignee
   end
 
   test "query for scheduled and unscheduled talks" do


### PR DESCRIPTION
Fixes #7 by checking if current_user == assignee before unassigning a talk. Removes the need for is_assigned and assigned_to columns since we can get that info from the user. Includes a bit of SQL magic in the migration so existing data will work correctly. We probably should test this on a copy of production data before putting it live to make sure there are no problems.
