### PR TITLE
Sort unscheduled talks by number of votes

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -4,7 +4,7 @@ class TalksController < ApplicationController
   ]
 
   def index
-    @unscheduled_talks = Talk.unscheduled
+    @unscheduled_talks = Talk.sorted_by_votes.unscheduled
     @scheduled_talks = Talk.scheduled
     @previous_talks = Talk.previous
   end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -4,7 +4,7 @@ class TalksController < ApplicationController
   ]
 
   def index
-    @unscheduled_talks = Talk.sorted_by_votes.unscheduled
+    @unscheduled_talks = Talk.unscheduled
     @scheduled_talks = Talk.scheduled
     @previous_talks = Talk.previous
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -3,7 +3,7 @@ class Talk < ActiveRecord::Base
   belongs_to :user
   belongs_to :assignee, class_name: 'User'
 
-  scope :unscheduled, -> { where(speak_date: nil).order(:topic) }
+  scope :unscheduled, -> { where(speak_date: nil).order(:assignee_id).sorted_by_votes.order(:topic) }
   scope :scheduled, -> { where('speak_date >= ?', Date.today).order(:speak_date).order(:topic) }
   scope :previous, -> { where('speak_date < ?', Date.today).order(:topic) }
   scope :sorted_by_votes, -> { order(votes_count: :desc) }

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -6,6 +6,7 @@ class Talk < ActiveRecord::Base
   scope :unscheduled, -> { where(speak_date: nil).order(:topic) }
   scope :scheduled, -> { where('speak_date >= ?', Date.today).order(:speak_date).order(:topic) }
   scope :previous, -> { where('speak_date < ?', Date.today).order(:topic) }
+  scope :sorted_by_votes, -> { order(votes_count: :desc) }
 
   # Add Validation
   validates :topic, presence: true, length: { minimum: 3 }

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,4 +1,4 @@
 class Vote < ActiveRecord::Base
-  belongs_to :talk
+  belongs_to :talk, counter_cache: true
   belongs_to :user
 end

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -20,7 +20,7 @@
     <div class="col-xs-12 col-sm-6 col-md-6 text-center">
       <%= button_to upvote_talk_path(talk), class: "btn btn-md btn-info custom-button", method: :post do %>
         <span class="glyphicon glyphicon-thumbs-up"></span>&nbsp;
-        <span class="badge"><%= talk.votes.count %></span>
+        <span class="badge"><%= talk.votes_count %></span>
       <% end %>
     </div>
 

--- a/db/migrate/20151016212530_add_votes_count_to_talks.rb
+++ b/db/migrate/20151016212530_add_votes_count_to_talks.rb
@@ -1,0 +1,6 @@
+class AddVotesCountToTalks < ActiveRecord::Migration
+  def change
+    add_column :talks, :votes_count, :integer, default: 0
+    Talk.find_each { |talk| Talk.reset_counters(talk.id, :votes) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922215620) do
+ActiveRecord::Schema.define(version: 20151016212530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,11 +19,12 @@ ActiveRecord::Schema.define(version: 20150922215620) do
   create_table "talks", force: :cascade do |t|
     t.string   "topic"
     t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.integer  "user_id"
     t.date     "speak_date"
     t.integer  "assignee_id"
+    t.integer  "votes_count", default: 0
   end
 
   add_index "talks", ["assignee_id"], name: "index_talks_on_assignee_id", using: :btree

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -24,5 +24,21 @@ class TalkTest < ActiveSupport::TestCase
     assert_not scheduled_talks.include? unscheduled_talk
     assert scheduled_talks.include? scheduled_talk
   end
+
+  test "voting updates counter" do
+    talk = FactoryGirl.create(:topic)
+    user = FactoryGirl.create(:user)
+    user.upvote(talk)
+    assert_equal talk.votes_count, 1
+  end
+
+  test "sort talks by votes" do
+    other_talk = FactoryGirl.create(:topic)
+    talk = FactoryGirl.create(:topic)
+    user = FactoryGirl.create(:user)
+    assert_equal Talk.sorted_by_votes.first, other_talk
+    user.upvote(talk)
+    assert_equal Talk.sorted_by_votes.first, talk
+  end
 end
 


### PR DESCRIPTION
There are quite a few unscheduled talks so it would be nice to sort them by number of votes to see what is popular. I used a counter cache on the votes association to track the number of votes. This allows sorting by number of votes without a complex join.
