### PR TITLE
Fix bug for index cards when scrolling on mobile devices

### DIFF
--- a/app/assets/javascripts/index_cards.js
+++ b/app/assets/javascripts/index_cards.js
@@ -67,24 +67,8 @@ $(document).ready(function() {
     });
   }
 
-  // Readjust cards' size when browser width changes
-  $(window).on('resize', function() {
-    // if check to cover for mobile devices
-    if ($windowWidth !== $(document).width()) {
-      $windowWidth = $(window).width();
-      heightToAuto();
-      removeAlignBottomStyles();
-
-      clearTimeout(windowResizeID);
-      windowResizeID = setTimeout(function() {
-        heightToLargestAnimated();
-        setAlignBottomStyles();
-      }, 700);
-    }
-  });
-
-  // Readjust cards' size when mobile orientation changes
-  $(window).on('orientationchange', function() {
+  // Readjust card size with a delay
+  function cardSizeReadjust(delay) {
     $windowWidth = $(window).width();
     heightToAuto();
     removeAlignBottomStyles();
@@ -93,7 +77,20 @@ $(document).ready(function() {
     windowResizeID = setTimeout(function() {
       heightToLargestAnimated();
       setAlignBottomStyles();
-    }, 1000);
+    }, delay);
+  }
+
+  // Readjust cards' size when browser width changes
+  $(window).on('resize', function() {
+    // if check to cover for scrolling on mobile devices
+    if ($windowWidth !== $(document).width()) {
+      cardSizeReadjust(700);
+    }
+  });
+
+  // Readjust cards' size when mobile orientation changes
+  $(window).on('orientationchange', function() {
+    cardSizeReadjust(1000);
   });
 
   heightToLargest();

--- a/app/assets/javascripts/index_cards.js
+++ b/app/assets/javascripts/index_cards.js
@@ -83,7 +83,7 @@ $(document).ready(function() {
   // Readjust cards' size when browser width changes
   $(window).on('resize', function() {
     // if check to cover for scrolling on mobile devices
-    if ($windowWidth !== $(document).width()) {
+    if ($windowWidth !== $(window).width()) {
       cardSizeReadjust(700);
     }
   });

--- a/app/assets/javascripts/index_cards.js
+++ b/app/assets/javascripts/index_cards.js
@@ -71,6 +71,7 @@ $(document).ready(function() {
   $(window).on('resize', function() {
     // if check to cover for mobile devices
     if ($windowWidth !== $(document).width()) {
+      $windowWidth = $(window).width();
       heightToAuto();
       removeAlignBottomStyles();
 

--- a/app/assets/javascripts/index_cards.js
+++ b/app/assets/javascripts/index_cards.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
 
   var windowResizeID,
+      $windowWidth = $(window).width(),
       $iceIndex = $('.ice-index'),
       $alignBottom = $('.align-bottom');
 
@@ -66,8 +67,24 @@ $(document).ready(function() {
     });
   }
 
-  // Readjust cards' size on index.html.erb when browser is resized
-  $(window).on('resize', function() { 
+  // Readjust cards' size when browser width changes
+  $(window).on('resize', function() {
+    // if check to cover for mobile devices
+    if ($windowWidth !== $(document).width()) {
+      heightToAuto();
+      removeAlignBottomStyles();
+
+      clearTimeout(windowResizeID);
+      windowResizeID = setTimeout(function() {
+        heightToLargestAnimated();
+        setAlignBottomStyles();
+      }, 700);
+    }
+  });
+
+  // Readjust cards' size when mobile orientation changes
+  $(window).on('orientationchange', function() {
+    $windowWidth = $(window).width();
     heightToAuto();
     removeAlignBottomStyles();
 
@@ -75,7 +92,7 @@ $(document).ready(function() {
     windowResizeID = setTimeout(function() {
       heightToLargestAnimated();
       setAlignBottomStyles();
-    }, 700);
+    }, 1000);
   });
 
   heightToLargest();


### PR DESCRIPTION
From researching for a fix to the bug for the index cards when viewing on mobile devices, I learned that the browser resize event is fired whenever a user scrolls on a mobile device because the scrollbar is hiding or showing, thus triggering a change in the size of the browser.

I added an if conditional check to the window resize event to cover for the mobile scrolling issue.

I also added an orientation change event to make sure the bug doesn't reappear when a user changes the orientation when viewing from a mobile device. I set the delay to 1000ms because the timing for this event apparently varies across browsers.

(I ran tests using Android phone, iPhone, iPad, and Desktop.)
