### PR TITLE
Added WYSIWYG text editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'bootstrap-sass'
 gem 'devise'
 # Simple form
 gem 'simple_form'
+# WYSIWYG text editor
+gem 'ckeditor'
 
 gem 'sdoc', '~> 0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,13 @@ GEM
       sass (>= 3.3.0)
     builder (3.2.2)
     byebug (6.0.2)
+    ckeditor (4.1.4)
+      cocaine
+      orm_adapter (~> 0.5.0)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -168,6 +175,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   byebug
+  ckeditor
   coffee-rails (~> 4.1.0)
   devise
   factory_girl_rails (~> 4.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require ckeditor/init
 //= require jquery
 //= require bootstrap-sprockets
 //= require jquery_ujs

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -1,7 +1,7 @@
 <div class="ice-index col-xs-12 col-sm-6 col-md-4">
   <h2><%= link_to talk.topic, talk_path(talk) %></h2>
   <br />
-  <h4><%= truncate talk.description, length: 80 %></h4>
+  <h4><%= truncate raw(talk.description), length: 80 %></h4>
   
   <% if talk.description.length > 80 %>
     <p><%= link_to "Read More...", talk_path(talk) %></p>

--- a/app/views/talks/edit.html.erb
+++ b/app/views/talks/edit.html.erb
@@ -2,7 +2,8 @@
   <h1>Edit the details of the topic</h1>
   <%= simple_form_for @talk do |f| %>
     <%= f.input :topic %><br />
-    <%= f.input :description %><br />
+    <%= f.label :description %>
+    <%= f.cktext_area :description %><br />
     <%= f.submit 'Update', class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/talks/new.html.erb
+++ b/app/views/talks/new.html.erb
@@ -2,7 +2,8 @@
   <h1>Enter the details of the topic</h1>
   <%= simple_form_for @talk do |f| %>
     <%= f.input :topic, required: false, error: 'Topic is required' %><br />
-    <%= f.input :description, required: false, error: "A description is required" %><br />
+    <%= f.label :description %>
+    <%= f.cktext_area :description, required: false, error: "A description is required" %><br />
     <%= f.submit 'Submit', class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -3,7 +3,7 @@
 <div class="ice col-xs-10 col-xs-offset-1">
   <h1><%= @talk.topic %></h1>
   <br />
-  <h3><%= @talk.description %></h3>
+  <h3><%= raw(@talk.description) %></h3>
   <br />
   <% if @talk.assignee.present? %>
     <p>Assigned to: <%= @talk.assignee.first_name %> <%= @talk.assignee.last_name.first %>.</p>


### PR DESCRIPTION
# Added WYSIWYG text editor
- Added a simple text editor for the description in the form to add new topics.
- Used the [Ckeditor gem](https://github.com/galetahub/ckeditor)
- Solves [this issue](https://github.com/FirehoseCommunity/LightningTalkTopics/issues/13)
- Formerly [this PR](https://github.com/FirehoseCommunity/LightningTalkTopics/pull/34)

![screen shot 2015-12-05 at 5 55 32 pm](https://cloud.githubusercontent.com/assets/13539307/11610705/7074ca40-9b79-11e5-93a0-164c743396aa.png)
