### PR TITLE
Allow admins to unassign talks

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,6 @@ class User < ActiveRecord::Base
   end
 
   def unassign(talk)
-    talk.update(assignee: nil) if talk.assignee == self
+    talk.update(assignee: nil) if talk.assignee == self || self.admin?
   end
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -67,6 +67,17 @@ class TalksControllerTest < ActionController::TestCase
     assert_equal user, talk.assignee
   end
 
+  test "admin user can unassign talk from other user" do
+    talk = FactoryGirl.create(:topic)
+    user = FactoryGirl.create(:user)
+    user.assign(talk)
+    admin = FactoryGirl.create(:admin)
+    sign_in admin
+    put :unassign, id: talk.id
+    talk.reload
+    assert talk.assignee.nil?
+  end
+  
   test "can assign talk to self" do
     talk = FactoryGirl.create(:topic)
     user = FactoryGirl.create(:user)


### PR DESCRIPTION
Updated the User model to allows admins to unassign a talk, and added a test for that scenario.
