### PR TITLE
Modified Navbar Brand Title text and UX.  Issue 44.

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -2,8 +2,7 @@
   <div class="container navigation-container">
     <div class="brand-wrapper">
       <img class="brand-logo" src="/assets/firehose_logo.png" alt="The Firehose Project Logo" />
-      <%= link_to 'Firehose Project', root_path, class: "brand-title" %>
-      <%= link_to 'Firehose', root_path, class: "brand-title-alt" %>
+      <%= link_to 'Lightning Talks', root_path, class: "brand-title" %>
     </div> <!-- End Brand Wrapper -->
 
     <div class="navigation-links-container">
@@ -12,6 +11,7 @@
         <% if user_signed_in? && current_user.admin %>
           <li><%= link_to "Admin", admin_index_path %></li>
         <% end %>
+        <li><%= link_to 'Lightning Talks', root_path, class: "brand-title-alt" %></li>
         <li>Firehose Links
           <ul class="navigation-dropdown-menu">
             <li><%= link_to "theFirehoseProject", "http://www.thefirehoseproject.com/", target: "_blank" %></li>


### PR DESCRIPTION
I changed the text of the Navbar brand-title AND the Navbar brand-title-alt (the mobile view version)  I moved the brand-title-alt into the hamburger menu.  I believe the relocation of the brand-title-alt will resolve the mobile view sizing/layout issue you mentioned in one of your comments on Issue #44 @colinrubbert.  It's clean and functional.

Full Browser view:
![screen shot 2016-08-26 at 1 39 49 pm](https://cloud.githubusercontent.com/assets/13741014/18016601/cca26e8c-6b92-11e6-8ead-79c141c02c65.png)

Mobile view:
![screen shot 2016-08-26 at 1 38 50 pm](https://cloud.githubusercontent.com/assets/13741014/18016608/d4db2ff8-6b92-11e6-8647-5aa684faeeea.png)

Mobile menu open:
![screen shot 2016-08-26 at 1 39 04 pm](https://cloud.githubusercontent.com/assets/13741014/18016615/deecbad4-6b92-11e6-8e9e-cdbd4746ace8.png)
