### PR TITLE
Remove firehose links from top navbar - Issue 46

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,3 @@ DEPENDENCIES
   spring
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.12.5

--- a/app/assets/stylesheets/2-components/_navigation.sass
+++ b/app/assets/stylesheets/2-components/_navigation.sass
@@ -79,22 +79,6 @@
       transition: $transition
       color: $primary-blue
 
-.navigation-dropdown-menu
-  display: none
-  list-style: none
-  padding: 0
-  margin: 0
-  li
-    padding: 10px
-  a
-    transition: $transition
-
-li:hover > .navigation-dropdown-menu
-  display: flex
-  flex-direction: column
-  padding-top: 20px
-  a:hover
-    color: $primary-blue
 
 @media screen and (min-width: $tablet-breakpoint)
   .navigation-links-wrapper
@@ -105,24 +89,6 @@ li:hover > .navigation-dropdown-menu
     li
       margin-left: 20px
       margin-bottom: 0
-
-  .navigation-dropdown-menu
-    border: 1px solid $light-gray
-    border-top: 1px solid transparent
-    background-color: $white
-    border-radius: 3px
-    opacity: 0
-    transform: translateY(-60%)
-    transition: .3s ease-in-out .1s
-    li
-      margin-left: 0
-    &:hover
-      opacity: 1
-      transform: translateY(0%)
-
-  li:hover > .navigation-dropdown-menu
-    display: block
-    position: absolute
 
   .mobile-navigation-toggle
     display: none

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,13 +12,6 @@
           <li><%= link_to "Admin", admin_index_path %></li>
         <% end %>
         <li><%= link_to 'Lightning Talks', root_path, class: "brand-title-alt" %></li>
-        <li>Firehose Links
-          <ul class="navigation-dropdown-menu">
-            <li><%= link_to "theFirehoseProject", "http://www.thefirehoseproject.com/", target: "_blank" %></li>
-            <li><%= link_to "Firehose Community", "http://community.thefirehoseproject.com/", target: "_blank" %></li>
-            <li><%= link_to "About", about_path %></li>
-          </ul>
-        </li>
         <li><%= link_to "Topics", talks_path %></li>
         <% if user_signed_in? %>
           <li>


### PR DESCRIPTION
Quick update to remove Firehose Links section from top navbar.  Cleaner navbar UI and links are in footer.  Issue #46 (not 45 as indicated in branch name)
